### PR TITLE
support 3 options for log buffer allocation

### DIFF
--- a/cdefmt/config/cdefmt_config.h
+++ b/cdefmt/config/cdefmt_config.h
@@ -1,6 +1,49 @@
 #ifndef CDEFMT_CONFIG_H
 #define CDEFMT_CONFIG_H
 
-#define CDEFMT_DYNAMIC_MAX_SIZE 128
+/* ======================================== Stack Buffer ======================================== */
+
+#define CDEFMT_USE_STACK_LOG_BUFFER 1
+
+#if defined(CDEFMT_USE_STACK_LOG_BUFFER) && CDEFMT_USE_STACK_LOG_BUFFER
+#define CDEFMT_STACK_LOG_BUFFER_DYNAMIC_SIZE_MAX 128
+#endif /* defined (CDEFMT_USE_STACK_LOG_BUFFER) && CDEFMT_USE_STACK_LOG_BUFFER */
+
+/* ======================================== Static Buffer ======================================= */
+
+/* Use a global static log buffer, otherwise a buffer will be created on the stack on each
+ * invocation of CDEFMT_LOG.
+ * If enabled and running in a multi-threaded environment, the following functions must be
+ * implemented by the user, as concurrent accesses to the buffer will cause corruption:
+ * - CDEFMT_STATIC_LOG_BUFFER_LOCK()
+ * - CDEFMT_STATIC_LOG_BUFFER_UNLOCK()
+ * As well as the following defines:
+ * - CDEFMT_STATIC_LOG_BUFFER      - accessor to the static log buffer.
+ * - CDEFMT_STATIC_LOG_BUFFER_SIZE - the static log buffer's size (in bytes).
+ */
+#define CDEFMT_USE_STATIC_LOG_BUFFER 0
+
+#if defined(CDEFMT_USE_STATIC_LOG_BUFFER) && CDEFMT_USE_STATIC_LOG_BUFFER
+#define CDEFMT_STATIC_LOG_BUFFER_LOCK()
+#define CDEFMT_STATIC_LOG_BUFFER_UNLOCK()
+#define CDEFMT_STATIC_LOG_BUFFER
+#define CDEFMT_STATIC_LOG_BUFFER_SIZE
+#endif /* defined (CDEFMT_USE_STATIC_LOG_BUFFER) && CDEFMT_USE_STATIC_LOG_BUFFER */
+
+/* ======================================= Dynamic Buffer ======================================= */
+
+/* Use a dynamically allocated log buffer, otherwise a buffer will be created on the stack on each
+ * invocation of CDEFMT_LOG.
+ * If enabled, a buffer will be allocated on the heap for each log, the following functions must be
+ * implemented by the user:
+ * - CDEFMT_DYNAMIC_LOG_BUFFER_ALLOC(size_)
+ * - CDEFMT_DYNAMIC_LOG_BUFFER_FREE()
+ */
+#define CDEFMT_USE_DYNAMIC_LOG_BUFFER 0
+
+#if defined(CDEFMT_USE_DYNAMIC_LOG_BUFFER) && CDEFMT_USE_DYNAMIC_LOG_BUFFER
+#define CDEFMT_DYNAMIC_LOG_BUFFER_ALLOC(size_)
+#define CDEFMT_DYNAMIC_LOG_BUFFER_FREE(buffer_)
+#endif /* defined (CDEFMT_USE_DYNAMIC_LOG_BUFFER) && CDEFMT_USE_DYNAMIC_LOG_BUFFER */
 
 #endif /* CDEFMT_CONFIG_H */

--- a/examples/stdout/config/cdefmt_config.h
+++ b/examples/stdout/config/cdefmt_config.h
@@ -3,7 +3,7 @@
 
 /* ======================================== Stack Buffer ======================================== */
 
-#define CDEFMT_USE_STACK_LOG_BUFFER 0
+#define CDEFMT_USE_STACK_LOG_BUFFER 1
 
 #if defined(CDEFMT_USE_STACK_LOG_BUFFER) && CDEFMT_USE_STACK_LOG_BUFFER
 #define CDEFMT_STACK_LOG_BUFFER_DYNAMIC_SIZE_MAX 128
@@ -45,7 +45,7 @@ extern pthread_mutex_t cdefmt_global_buffer_lock;
  * - CDEFMT_DYNAMIC_LOG_BUFFER_ALLOC(size_)
  * - CDEFMT_DYNAMIC_LOG_BUFFER_FREE()
  */
-#define CDEFMT_USE_DYNAMIC_LOG_BUFFER 1
+#define CDEFMT_USE_DYNAMIC_LOG_BUFFER 0
 
 #if defined(CDEFMT_USE_DYNAMIC_LOG_BUFFER) && CDEFMT_USE_DYNAMIC_LOG_BUFFER
 #include <stdlib.h>

--- a/examples/stdout/config/cdefmt_config.h
+++ b/examples/stdout/config/cdefmt_config.h
@@ -1,6 +1,57 @@
 #ifndef CDEFMT_CONFIG_H
 #define CDEFMT_CONFIG_H
 
-#define CDEFMT_DYNAMIC_MAX_SIZE 256
+/* ======================================== Stack Buffer ======================================== */
+
+#define CDEFMT_USE_STACK_LOG_BUFFER 0
+
+#if defined(CDEFMT_USE_STACK_LOG_BUFFER) && CDEFMT_USE_STACK_LOG_BUFFER
+#define CDEFMT_STACK_LOG_BUFFER_DYNAMIC_SIZE_MAX 128
+#endif /* defined (CDEFMT_USE_STACK_LOG_BUFFER) && CDEFMT_USE_STACK_LOG_BUFFER */
+
+/* ======================================== Static Buffer ======================================= */
+
+/* Use a global static log buffer, otherwise a buffer will be created on the stack on each
+ * invocation of CDEFMT_LOG.
+ * If enabled and running in a multi-threaded environment, the following functions must be
+ * implemented by the user, as concurrent accesses to the buffer will cause corruption:
+ * - CDEFMT_STATIC_LOG_BUFFER_LOCK()
+ * - CDEFMT_STATIC_LOG_BUFFER_UNLOCK()
+ * As well as the following defines:
+ * - CDEFMT_STATIC_LOG_BUFFER      - accessor to the static log buffer.
+ * - CDEFMT_STATIC_LOG_BUFFER_SIZE - the static log buffer's size (in bytes).
+ */
+#define CDEFMT_USE_STATIC_LOG_BUFFER 0
+
+#if defined(CDEFMT_USE_STATIC_LOG_BUFFER) && CDEFMT_USE_STATIC_LOG_BUFFER
+#include <pthread.h>
+#include <stdint.h>
+
+#define CDEFMT_STATIC_LOG_BUFFER_LOCK()   pthread_mutex_lock(&cdefmt_global_buffer_lock)
+#define CDEFMT_STATIC_LOG_BUFFER_UNLOCK() pthread_mutex_unlock(&cdefmt_global_buffer_lock)
+#define CDEFMT_STATIC_LOG_BUFFER          cdefmt_global_buffer
+#define CDEFMT_STATIC_LOG_BUFFER_SIZE     512
+
+extern uint8_t cdefmt_global_buffer[CDEFMT_STATIC_LOG_BUFFER_SIZE];
+extern pthread_mutex_t cdefmt_global_buffer_lock;
+#endif /* defined (CDEFMT_USE_STATIC_LOG_BUFFER) && CDEFMT_USE_STATIC_LOG_BUFFER */
+
+/* ======================================= Dynamic Buffer ======================================= */
+
+/* Use a dynamically allocated log buffer, otherwise a buffer will be created on the stack on each
+ * invocation of CDEFMT_LOG.
+ * If enabled, a buffer will be allocated on the heap for each log, the following functions must be
+ * implemented by the user:
+ * - CDEFMT_DYNAMIC_LOG_BUFFER_ALLOC(size_)
+ * - CDEFMT_DYNAMIC_LOG_BUFFER_FREE()
+ */
+#define CDEFMT_USE_DYNAMIC_LOG_BUFFER 1
+
+#if defined(CDEFMT_USE_DYNAMIC_LOG_BUFFER) && CDEFMT_USE_DYNAMIC_LOG_BUFFER
+#include <stdlib.h>
+
+#define CDEFMT_DYNAMIC_LOG_BUFFER_ALLOC(size_)  calloc(1, size_)
+#define CDEFMT_DYNAMIC_LOG_BUFFER_FREE(buffer_) free(buffer_)
+#endif /* defined (CDEFMT_USE_DYNAMIC_LOG_BUFFER) && CDEFMT_USE_DYNAMIC_LOG_BUFFER */
 
 #endif /* CDEFMT_CONFIG_H */


### PR DESCRIPTION
The options are as follows:
* on stack - as previously, buffer is allocated on stack and "destoyed" once out of scope
* static buffer - a static buffer is shared by all log invocations, protected by some lock. This allows generating large logs without affecting thread stack depth.
* dynamic buffer - the buffer is dynamically allocated and freed using user provided functions. The user can allocate these buffers from memory pools or whatever, and leave the free implementation empty, if he chooses to free the buffer himself at a later point.