### PR TITLE
Struct metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,12 @@
 [workspace]
 members = ["decoder", "parser", "examples/stdin"]
 resolver = "2"
+
+[workspace.package]
+authors = ["Tal Risin <tal@risin.dev>"]
+edition = "2021"
+keywords = ["cdefmt", "defmt"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/risint96/cdefmt"
+version = "0.6.0"

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -14,7 +14,4 @@ gimli = "0.31"
 object = "0.36"
 lazy-regex = "3.4"
 cdefmt-parser = { path = "../parser", version = "0.5.0" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_repr = "0.1"
 thiserror = "2.0"

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-authors = ["Tal Risin"]
+authors.workspace = true
 description = "Decodes cdefmt log frames"
-edition = "2021"
-keywords = ["cdefmt", "defmt"]
-license = "MIT"
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
 name = "cdefmt-decoder"
-readme = "../README.md"
-repository = "https://github.com/risint96/cdefmt"
-version = "0.5.0"
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 gimli = "0.31"
 object = "0.36"
 lazy-regex = "3.4"
-cdefmt-parser = { path = "../parser", version = "0.5.0" }
+cdefmt-parser = { path = "../parser", version = "0.6.0" }
 thiserror = "2.0"

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -11,8 +11,6 @@ pub use decoder::Decoder;
 pub enum Error {
     #[error("Gimli error: {0}")]
     Gimli(#[from] gimli::Error),
-    #[error("Json error: {0}")]
-    Json(#[from] serde_json::Error),
     #[error("{0}")]
     Parser(#[from] cdefmt_parser::Error),
     #[error("The provided elf is missing the '.cdefmt' section.")]

--- a/decoder/src/log.rs
+++ b/decoder/src/log.rs
@@ -13,13 +13,13 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct Log {
-    metadata: Metadata,
+pub struct Log<'elf> {
+    metadata: Metadata<'elf>,
     args: Option<Vec<Var>>,
 }
 
-impl Log {
-    pub(crate) fn new(metadata: Metadata, args: Option<Vec<Var>>) -> Self {
+impl<'elf> Log<'elf> {
+    pub(crate) fn new(metadata: Metadata<'elf>, args: Option<Vec<Var>>) -> Self {
         Self { metadata, args }
     }
 
@@ -28,7 +28,7 @@ impl Log {
     }
 
     pub fn get_file(&self) -> &str {
-        &self.metadata.file
+        self.metadata.file
     }
 
     pub fn get_line(&self) -> usize {
@@ -40,11 +40,11 @@ impl Log {
     }
 
     fn get_format_fragments(&self) -> FormatStringFragmentIterator {
-        FormatStringFragmentIterator::new(&self.metadata.format_string)
+        FormatStringFragmentIterator::new(self.metadata.fmt)
     }
 }
 
-impl std::fmt::Display for Log {
+impl std::fmt::Display for Log<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut index = 0;
 
@@ -63,7 +63,7 @@ impl std::fmt::Display for Log {
                             &args[position]
                         }
                         Some(ParameterPosition::Named(name)) => {
-                            if let Some(pos) = self.metadata.names.iter().position(|n| n == name) {
+                            if let Some(pos) = self.metadata.names.iter().position(|&n| n == name) {
                                 &args[pos]
                             } else {
                                 write!(f, "{{No named parameter '{name}'}}")?;

--- a/examples/stdin/Cargo.toml
+++ b/examples/stdin/Cargo.toml
@@ -1,12 +1,18 @@
 [package]
+authors.workspace = true
+description = "Reads cdefmt log frames encoded as TL from stdin, decodes them, and prints them to stdout"
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
 name = "stdin"
-version = "0.2.0"
-edition = "2021"
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cdefmt-decoder = { path = "../../decoder", version = "0.5.0" }
+cdefmt-decoder = { path = "../../decoder", version = "0.6.0" }
 clap = { version = "4.5", features = ["derive"] }
 gimli = "0.31"
 memmap2 = "0.9"

--- a/examples/stdin/src/main.rs
+++ b/examples/stdin/src/main.rs
@@ -1,6 +1,5 @@
 use std::{io::Read, path::PathBuf};
 
-use cdefmt_decoder;
 use clap::Parser;
 use gimli::Reader;
 
@@ -22,9 +21,8 @@ fn main() -> std::result::Result<(), String> {
     let file = std::fs::File::open(args.elf).map_err(|e| e.to_string())?;
     let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(|e| e.to_string())?;
 
-    let mut decoder = cdefmt_decoder::Decoder::new(&*mmap).map_err(|e| e.to_string())?;
-
     let start = std::time::Instant::now();
+    let mut decoder = cdefmt_decoder::Decoder::new(&*mmap).map_err(|e| e.to_string())?;
     let count = decoder.precache_log_metadata().map_err(|e| e.to_string())?;
     let duration = start.elapsed();
 
@@ -54,8 +52,6 @@ fn main() -> std::result::Result<(), String> {
             Ok(log) => println!("{:<7} > {}", log.get_level(), log),
             Err(e) => println!("Err: {}", e),
         }
-
-        buff.clear();
     }
 
     Ok(())

--- a/examples/stdout/linkerscript.ld
+++ b/examples/stdout/linkerscript.ld
@@ -263,7 +263,6 @@ SECTIONS
   /* CDEFMT: logs section */
   .cdefmt 0 (INFO) : {
     KEEP(*(.cdefmt.init .cdefmt.init.*))
-    . = . + 8;
     KEEP(*(.cdefmt .cdefmt.*))
   }
   /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -12,8 +12,4 @@ version = "0.5.0"
 [dependencies]
 gimli = "0.31"
 object = "0.36"
-lazy-regex = "3.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_repr = "0.1"
-quick-xml = { version = "0.37.2", features = ["serialize"] }
 thiserror = "2.0"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-authors = ["Tal Risin"]
+authors.workspace = true
 description = "Parsing library for cdefmt log frames"
-edition = "2021"
-keywords = ["cdefmt", "defmt"]
-license = "MIT"
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
 name = "cdefmt-parser"
-readme = "../README.md"
-repository = "https://github.com/risint96/cdefmt"
-version = "0.5.0"
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 gimli = "0.31"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -12,8 +12,6 @@ pub use parser::Parser;
 pub enum Error {
     #[error("Gimli error: {0}")]
     Gimli(#[from] gimli::Error),
-    #[error("XML error: {0}")]
-    XML(#[from] quick_xml::DeError),
     #[error("The provided elf is missing the '.cdefmt' section.")]
     MissingSection,
     #[error("DIE is missing attribute {0}")]
@@ -26,7 +24,7 @@ pub enum Error {
     NoSection(SectionId),
     #[error("Unable to find requested type ({0}).")]
     NoType(String),
-    #[error("Provided log id [{0}] is larger than the '.cdefmt' section [{1}]")]
+    #[error("Provided log at ID [{0}] metadata exceeds the '.cdefmt' section [{1}]")]
     OutOfBounds(usize, usize),
     #[error("Failed extract data from the '.cdefmt' section, error: {0}")]
     SectionData(#[from] object::Error),

--- a/parser/src/metadata.rs
+++ b/parser/src/metadata.rs
@@ -1,18 +1,19 @@
 //! Representation of log metadata extracted from the target elf's .cdefmt section.
 
-use core::fmt;
+use core::{fmt, str};
 
-use serde::Deserialize;
-use serde_repr::Deserialize_repr;
+use gimli::{EndianSlice, Reader, RunTimeEndian};
 
-#[derive(Clone, Copy, Debug, Deserialize_repr)]
+use crate::{Error, Result};
+
+#[derive(Clone, Copy, Debug)]
 #[repr(u8)]
 pub enum Level {
-    Error,
-    Warning,
-    Info,
-    Debug,
-    Verbose,
+    Error = 0,
+    Warning = 1,
+    Info = 2,
+    Debug = 3,
+    Verbose = 4,
 }
 
 impl fmt::Display for Level {
@@ -21,26 +22,93 @@ impl fmt::Display for Level {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct SchemaVersion {
-    #[serde(rename = "@version")]
-    pub version: u32,
+#[derive(Clone, Debug)]
+pub struct Metadata<'elf> {
+    pub id: usize,
+    pub counter: u32,
+    pub line: usize,
+    pub file: &'elf str,
+    pub fmt: &'elf str,
+    pub names: Vec<&'elf str>,
+    pub level: Level,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct Metadata {
-    #[serde(skip)]
-    pub id: usize,
-    #[serde(rename = "@counter")]
-    pub counter: usize,
-    #[serde(rename = "@level")]
-    pub level: Level,
-    #[serde(rename = "@file")]
-    pub file: String,
-    #[serde(rename = "@line")]
-    pub line: usize,
-    #[serde(rename = "@names")]
-    pub names: Vec<String>,
-    #[serde(rename = "$text")]
-    pub format_string: String,
+fn parse_metadata_impl<'elf>(
+    id: usize,
+    endian_slice: &mut EndianSlice<'elf, RunTimeEndian>,
+) -> Result<(Metadata<'elf>, usize)> {
+    let mut offset = 0;
+
+    let version = endian_slice.read_u32()?;
+    offset += 4;
+
+    if version != 1 {
+        return Err(Error::SchemaVersion(version));
+    }
+
+    let counter = endian_slice.read_u32()?;
+    let line = endian_slice.read_u32()? as usize;
+    offset += 4 * 2;
+
+    let file_len = endian_slice.read_u32()? as usize;
+    let fmt_len = endian_slice.read_u32()? as usize;
+    let names_len = endian_slice.read_u32()? as usize;
+    offset += 4 * 3;
+
+    let level = endian_slice.read_u8()?;
+    offset += 1;
+
+    let file = endian_slice.split(file_len)?;
+    let file = str::from_utf8(&file.slice()[..file_len - 1]).map_err(|e| Error::Utf8(id, e))?;
+    offset += file_len;
+
+    let fmt = endian_slice.split(fmt_len)?;
+    let fmt = str::from_utf8(&fmt.slice()[..fmt_len - 1]).map_err(|e| Error::Utf8(id, e))?;
+    offset += fmt_len;
+
+    let names = (0..names_len)
+        .map(|_| {
+            let name_len = endian_slice.read_u32()? as usize;
+            offset += 4;
+            let name = endian_slice.split(name_len)?;
+            offset += name_len;
+            str::from_utf8(&name.slice()[..name_len - 1]).map_err(|e| Error::Utf8(id, e))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok((
+        Metadata {
+            id,
+            counter,
+            line,
+            file,
+            fmt,
+            names,
+            level: unsafe { std::mem::transmute::<u8, Level>(level) },
+        },
+        offset,
+    ))
+}
+
+pub(crate) fn parse_metadata(
+    cdefmt_section: &[u8],
+    id: usize,
+    endian: RunTimeEndian,
+) -> Result<Metadata> {
+    let mut endian_slice = EndianSlice::new(cdefmt_section, endian);
+
+    endian_slice
+        .skip(id)
+        .map_err(|_| Error::OutOfBounds(id, cdefmt_section.len()))?;
+
+    Ok(parse_metadata_impl(id, &mut endian_slice)
+        .map_err(|e| {
+            // If the error is a gimli error, we want to convert it to an OutOfBounds error.
+            if let Error::Gimli(_) = e {
+                Error::OutOfBounds(id, cdefmt_section.len())
+            } else {
+                e
+            }
+        })?
+        .0)
 }


### PR DESCRIPTION
Encode metadata as a c struct, this allows more robust parsing as strings are encoded as-is and don't require any escaping.